### PR TITLE
Remove unused request generics from tool config

### DIFF
--- a/pylti1p3/contrib/fastapi/message_launch.py
+++ b/pylti1p3/contrib/fastapi/message_launch.py
@@ -10,7 +10,7 @@ from pylti1p3.tool_config.abstract import ToolConfAbstract
 from .cookie import FastAPICookieService
 from .session import FastAPISessionService
 
-ToolConfT = TypeVar("ToolConfT", bound=ToolConfAbstract[Any])
+ToolConfT = TypeVar("ToolConfT", bound=ToolConfAbstract)
 
 class FastAPIMessageLaunch(MessageLaunch[FastAPIRequest, ToolConfT, FastAPISessionService, FastAPICookieService]):
     def __init__(

--- a/pylti1p3/message_launch.py
+++ b/pylti1p3/message_launch.py
@@ -137,7 +137,7 @@ class TJwtData(t.TypedDict, total=False):
 
 
 RequestT = t.TypeVar("RequestT", bound=Request)
-ToolConfT = t.TypeVar("ToolConfT", bound=ToolConfAbstract[t.Any])
+ToolConfT = t.TypeVar("ToolConfT", bound=ToolConfAbstract)
 SessionServiceT = t.TypeVar("SessionServiceT", bound=SessionService)
 CookieServiceT = t.TypeVar("CookieServiceT", bound=CookieService)
 
@@ -634,10 +634,7 @@ class MessageLaunch(t.Generic[RequestT, ToolConfT, SessionServiceT, CookieServic
         jwt_body = self._get_jwt_body()
         client_id = self.get_client_id()
 
-        # Mypy doesn't support higher kinded types yet so it thinks that all
-        # generic attrs have type `Any`. See issue:
-        # https://github.com/python/mypy/issues/8228
-        config: ToolConfAbstract[RequestT] = self._tool_config
+        config: ToolConfAbstract = self._tool_config
         req: RequestT = self._request
 
         # Find registration

--- a/pylti1p3/oidc_login.py
+++ b/pylti1p3/oidc_login.py
@@ -17,7 +17,7 @@ from .tool_config import ToolConfAbstract
 
 RedirectT = t.TypeVar("RedirectT")
 RequestT = t.TypeVar("RequestT", bound=Request)
-ToolConfT = t.TypeVar("ToolConfT", bound=ToolConfAbstract[t.Any])
+ToolConfT = t.TypeVar("ToolConfT", bound=ToolConfAbstract)
 SessionServiceT = t.TypeVar("SessionServiceT", bound=SessionService)
 CookieServiceT = t.TypeVar("CookieServiceT", bound=CookieService)
 

--- a/pylti1p3/tool_config/abstract.py
+++ b/pylti1p3/tool_config/abstract.py
@@ -4,10 +4,6 @@ import collections.abc
 from abc import ABC, abstractmethod
 from ..deployment import Deployment
 from ..registration import Registration
-from ..request import Request
-
-
-RequestT = t.TypeVar("RequestT", bound=Request)
 
 
 class IssuerToClientRelation(StrEnum):
@@ -15,7 +11,7 @@ class IssuerToClientRelation(StrEnum):
     MANY_CLIENTS_IDS_PER_ISSUER = "one-issuer-many-client-ids"
 
 
-class ToolConfAbstract(t.Generic[RequestT], ABC):
+class ToolConfAbstract(ABC):
     issuers_relation_types: collections.abc.MutableMapping[str, IssuerToClientRelation] = {}
 
     def check_iss_has_one_client(self, iss: str) -> bool:

--- a/pylti1p3/tool_config/dict.py
+++ b/pylti1p3/tool_config/dict.py
@@ -1,7 +1,6 @@
 import typing as t
 from ..deployment import Deployment
 from ..registration import Registration, TKeySet
-from ..request import Request
 from .abstract import ToolConfAbstract
 
 class TIssConf(t.TypedDict, total=False):
@@ -18,9 +17,9 @@ class TIssConf(t.TypedDict, total=False):
     public_key_file: str | None
 
 TJsonData = dict[str, list[TIssConf] | TIssConf]
-RequestT = t.TypeVar("RequestT", bound=Request)
 
-class ToolConfDict(t.Generic[RequestT], ToolConfAbstract[RequestT]):
+
+class ToolConfDict(ToolConfAbstract):
     _config: TJsonData
     _private_key_one_client: dict[str, str]
     _public_key_one_client: dict[str, str]

--- a/pylti1p3/tool_config/json_file.py
+++ b/pylti1p3/tool_config/json_file.py
@@ -2,14 +2,10 @@ import typing as t
 import json
 import os
 
-from ..request import Request
-
 from .dict import ToolConfDict, TIssConf, TJsonData
 
 
-RequestT = t.TypeVar("RequestT", bound=Request)
-
-class ToolConfJsonFile(t.Generic[RequestT], ToolConfDict[RequestT]):
+class ToolConfJsonFile(ToolConfDict):
     _configs_dir: str
 
     def __init__(self, config_file: str):


### PR DESCRIPTION
## Summary
- remove the unused `RequestT` type parameter from the tool configuration base classes and JSON/dict implementations
- adjust MessageLaunch, OIDCLogin, and FastAPIMessageLaunch generics to match the simplified tool configuration types

## Testing
- python -m compileall pylti1p3

------
https://chatgpt.com/codex/tasks/task_e_68cd07e6d5888322a64696d22f3dab15