### PR TITLE
Add RedisCacheDataStorage contrib class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -642,6 +642,27 @@ Flask cache data storage
         message_launch = DjangoMessageLaunch.from_cache(launch_id, request, tool_conf,
                                                         launch_data_storage=launch_data_storage)
 
+
+Redis cache data storage
+------------------------
+
+.. code-block:: python
+
+    import redis
+    from pylti1p3.contrib import RedisCacheDataStorage
+
+    redis_client = redis.Redis(host="localhost", port=6379, db=0)
+
+    def login(request):
+        ...
+        launch_data_storage = RedisCacheDataStorage(redis_client)
+        oidc_login = DjangoOIDCLogin(request, tool_conf, launch_data_storage=launch_data_storage)
+
+    def launch(request):
+        ...
+        launch_data_storage = RedisCacheDataStorage(redis_client)
+        message_launch = DjangoMessageLaunch(request, tool_conf, launch_data_storage=launch_data_storage)
+
 Cache for Public Key
 ====================
 

--- a/pylti1p3/contrib/__init__.py
+++ b/pylti1p3/contrib/__init__.py
@@ -1,0 +1,2 @@
+
+from .redis_cache_data_storage import RedisCacheDataStorage as RedisCacheDataStorage

--- a/pylti1p3/contrib/redis_cache_data_storage.py
+++ b/pylti1p3/contrib/redis_cache_data_storage.py
@@ -1,0 +1,41 @@
+import json
+import typing as t
+
+from pylti1p3.launch_data_storage.base import LaunchDataStorage
+
+T = t.TypeVar("T")
+
+
+class RedisCacheDataStorage(LaunchDataStorage[T], t.Generic[T]):
+    _redis: t.Any = None
+
+    def __init__(self, redis_client: t.Any, **kwargs: t.Any) -> None:
+        self._redis = redis_client
+        super().__init__(**kwargs)
+
+    def _get_redis(self) -> t.Any:
+        assert self._redis is not None, "Redis client is not set"
+        return self._redis
+
+    def get_value(self, key: str) -> T:
+        key = self._prepare_key(key)
+        value = self._get_redis().get(key)
+        if value is None:
+            return t.cast(T, None)
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        if isinstance(value, str):
+            return t.cast(T, json.loads(value))
+        return t.cast(T, value)
+
+    def set_value(self, key: str, value: T, exp: int | None = None) -> None:
+        key = self._prepare_key(key)
+        payload = json.dumps(value)
+        self._get_redis().set(key, payload, ex=exp)
+
+    def check_value(self, key: str) -> bool:
+        key = self._prepare_key(key)
+        return self._get_redis().exists(key) == 1
+
+    def can_set_keys_expiration(self) -> bool:
+        return True

--- a/tests/test_redis_cache_data_storage.py
+++ b/tests/test_redis_cache_data_storage.py
@@ -1,0 +1,53 @@
+from pylti1p3.contrib import RedisCacheDataStorage
+
+
+class FakeRedis:
+    _data = None
+
+    def __init__(self):
+        self._data = {}
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def set(self, key, value, ex=None):  # pylint: disable=unused-argument
+        self._data[key] = value
+
+    def exists(self, key):
+        return 1 if key in self._data else 0
+
+
+class TestRedisCacheDataStorage:
+    def test_set_and_get_value(self):
+        redis = FakeRedis()
+        storage = RedisCacheDataStorage(redis)
+
+        storage.set_value("launch", {"state": "state-123", "nonce": "nonce-123"})
+
+        launch_data = storage.get_value("launch")
+
+        assert launch_data == {"state": "state-123", "nonce": "nonce-123"}
+
+    def test_check_value(self):
+        redis = FakeRedis()
+        storage = RedisCacheDataStorage(redis)
+
+        storage.set_value("state", {"key": "value"})
+
+        assert storage.check_value("state") is True
+        assert storage.check_value("missing") is False
+
+    def test_session_prefix(self):
+        redis = FakeRedis()
+        storage = RedisCacheDataStorage(redis)
+        storage.set_session_id("session-123")
+
+        storage.set_value("state", {"key": "value"})
+
+        assert storage.get_value("state") == {"key": "value"}
+        assert redis.exists("lti1p3-session-123-state") == 1
+
+    def test_can_set_keys_expiration(self):
+        storage = RedisCacheDataStorage(FakeRedis())
+
+        assert storage.can_set_keys_expiration() is True


### PR DESCRIPTION
### Motivation
- Provide a framework-agnostic launch data storage adapter for projects that use Redis directly instead of framework cache wrappers.
- Allow storing LTI launch/session payloads in Redis while preserving the existing key-prefix and session-id semantics from `LaunchDataStorage`.
- Make Redis-backed caching available for public-key and launch/session flows without requiring Django or Flask cache integration.

### Description
- Add `RedisCacheDataStorage` in `pylti1p3.contrib` which implements `get_value`, `set_value`, `check_value`, and `can_set_keys_expiration` using a provided Redis client and JSON serialization.
- Preserve key preparation and session prefixing behavior by reusing `LaunchDataStorage._prepare_key` semantics.
- Export `RedisCacheDataStorage` from `pylti1p3.contrib` for direct import as `from pylti1p3.contrib import RedisCacheDataStorage`.
- Document usage in `README.rst` under a new "Redis cache data storage" section and add focused unit tests using a `FakeRedis` client to cover set/get, existence checks, session-prefixing, and expiration capability.

### Testing
- `python -m compileall pylti1p3/contrib/redis_cache_data_storage.py tests/test_redis_cache_data_storage.py` succeeded.
- A smoke test script instantiating `RedisCacheDataStorage` with a fake Redis client and exercising `set_value`, `get_value`, and `check_value` succeeded.
- Running `pytest -q tests/test_redis_cache_data_storage.py` in this environment failed during collection due to a missing development dependency (`requests_mock`) referenced by other test modules, not due to the new tests themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd17b09dc8832281265e36e650a31a)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `RedisCacheDataStorage` class under `pylti1p3/contrib` that provides a framework-agnostic LTI launch data storage adapter backed by a Redis client, filling a gap for projects that use Redis directly rather than a Django/Flask cache wrapper. The implementation correctly inherits from `LaunchDataStorage`, reuses `_prepare_key` semantics for key prefixing and session scoping, and applies JSON serialization/deserialization when reading and writing values.

**Key observations:**
- The core implementation is correct and follows the existing patterns from `CacheDataStorage` and `DjangoCacheDataStorage`.
- `get_value` handles both `bytes` and `str` Redis responses, but has no guard against `json.JSONDecodeError` if a non-JSON value is stored under the same key prefix by an external process.
- `check_value` uses `exists(key) == 1`, which works for a single key but is less clear and more fragile than `bool(exists(key))`.
- `FakeRedis.set()` in the test suite silently discards the `ex` argument, so the `exp → ex` forwarding path in `set_value` is never exercised — a bug there would go undetected.
- The previously empty `pylti1p3/contrib/__init__.py` now unconditionally imports `RedisCacheDataStorage`. This is safe (no `redis` package import occurs in the module), but it does add a new symbol to the `pylti1p3.contrib` namespace for all existing users of the package.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor improvements recommended before production use.
- The core logic is sound, correctly implements the abstract interface, and is consistent with existing contrib adapters. No breaking changes are introduced. The main gaps are in test coverage (expiration forwarding is never validated) and a missing `json.JSONDecodeError` guard in `get_value`, both of which are non-critical for a contrib utility but worth addressing before widespread adoption.
- `tests/test_redis_cache_data_storage.py` — the `FakeRedis` fixture silently drops expiration, leaving the most Redis-specific behavior path untested.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pylti1p3/contrib/redis_cache_data_storage.py | New framework-agnostic Redis storage adapter implementing all required abstract methods; correctly handles bytes/str decoding and key prefixing, but lacks JSON error handling in `get_value` and uses a fragile `exists() == 1` comparison in `check_value`. |
| pylti1p3/contrib/__init__.py | Previously empty `__init__.py` now unconditionally imports `RedisCacheDataStorage`; safe since no `redis` package import occurs here, but changes the `pylti1p3.contrib` namespace for all downstream users. |
| tests/test_redis_cache_data_storage.py | Unit tests cover set/get, existence checks, session prefixing, and expiration capability, but `FakeRedis` silently drops the `ex` argument so the expiration forwarding path is never verified; also missing coverage for the bytes-decoding path. |
| README.rst | Adds a "Redis cache data storage" section with a clear usage example; consistent with existing documentation style, though imports for `DjangoOIDCLogin`/`DjangoMessageLaunch` are not shown in the snippet. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant RedisCacheDataStorage
    participant LaunchDataStorage (base)
    participant RedisClient

    App->>RedisCacheDataStorage: set_value(key, value, exp)
    RedisCacheDataStorage->>LaunchDataStorage (base): _prepare_key(key)
    Note over LaunchDataStorage (base): Applies lti1p3- prefix<br/>and optional session-id
    LaunchDataStorage (base)-->>RedisCacheDataStorage: prepared_key
    RedisCacheDataStorage->>RedisCacheDataStorage: json.dumps(value)
    RedisCacheDataStorage->>RedisClient: set(prepared_key, payload, ex=exp)

    App->>RedisCacheDataStorage: get_value(key)
    RedisCacheDataStorage->>LaunchDataStorage (base): _prepare_key(key)
    LaunchDataStorage (base)-->>RedisCacheDataStorage: prepared_key
    RedisCacheDataStorage->>RedisClient: get(prepared_key)
    RedisClient-->>RedisCacheDataStorage: bytes | str | None
    alt value is bytes
        RedisCacheDataStorage->>RedisCacheDataStorage: decode("utf-8")
    end
    RedisCacheDataStorage->>RedisCacheDataStorage: json.loads(value)
    RedisCacheDataStorage-->>App: T

    App->>RedisCacheDataStorage: check_value(key)
    RedisCacheDataStorage->>LaunchDataStorage (base): _prepare_key(key)
    LaunchDataStorage (base)-->>RedisCacheDataStorage: prepared_key
    RedisCacheDataStorage->>RedisClient: exists(prepared_key)
    RedisClient-->>RedisCacheDataStorage: 0 or 1
    RedisCacheDataStorage-->>App: bool
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: pylti1p3/contrib/redis_cache_data_storage.py
Line: 28

Comment:
**No error handling for malformed JSON**

If a key stored under the same `lti1p3-` prefix by an external process contains a non-JSON value, `json.loads(value)` will raise a bare `json.JSONDecodeError` with no contextual information about which key caused the failure. Wrapping this in a try-except and re-raising with context (or returning `None`) makes debugging much easier in production.

```suggestion
        try:
            return t.cast(T, json.loads(value))
        except json.JSONDecodeError:
            return t.cast(T, None)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: pylti1p3/contrib/redis_cache_data_storage.py
Line: 38

Comment:
**`exists() == 1` is fragile**

The Redis `EXISTS` command accepts multiple keys and returns the total count of matching keys (e.g. `redis.exists("a", "b")` returns `2` if both exist). While this is called with a single key here, comparing against the literal `1` is less semantically clear than testing for a non-zero count. A reader or future maintainer could mistakenly pass multiple keys and get silent `False` for existing keys.

```suggestion
        return bool(self._get_redis().exists(key))
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/test_redis_cache_data_storage.py
Line: 13

Comment:
**Expiration argument is silently dropped in `FakeRedis`**

`FakeRedis.set()` ignores the `ex` parameter entirely. Combined with the fact that `can_set_keys_expiration()` returns `True`, there is no test that verifies the `exp` argument passed to `set_value` is actually forwarded to the Redis client as `ex`. A bug here (e.g. passing `expire=` instead of `ex=`) would go completely undetected.

Consider capturing the `ex` argument in `FakeRedis` and adding a test case:

```python
def set(self, key, value, ex=None):
    self._data[key] = (value, ex)

def get(self, key):
    entry = self._data.get(key)
    return entry[0] if entry is not None else None
```

Then add a test:

```python
def test_set_value_passes_expiration_to_redis(self):
    redis = FakeRedis()
    storage = RedisCacheDataStorage(redis)
    storage.set_value("key", {"a": 1}, exp=300)
    # verify ex=300 was forwarded
    assert redis._data["lti1p3-key"][1] == 300
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/test_redis_cache_data_storage.py
Line: 4-8

Comment:
**Mutable class-level default in `FakeRedis`**

`_data = None` is defined as a class-level attribute, then overridden with `self._data = {}` in `__init__`. This pattern is a common Python pitfall: if `__init__` were accidentally bypassed (e.g. via `FakeRedis.__new__(FakeRedis)` or subclassing), all instances would share the class-level `None`, leading to `AttributeError` or unexpected state sharing. A type annotation without assignment is idiomatic here:

```suggestion
class FakeRedis:
    _data: dict

    def __init__(self):
        self._data = {}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Add RedisCacheDataSt..."](https://github.com/fyp-peerassessment/pylti1.3/commit/bbd30880117e75ab4cf5dc4d6d2cafe60dab253f)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->