### PR TITLE
Omit empty custom fields in deep-link content items

### DIFF
--- a/pylti1p3/deep_link_resource.py
+++ b/pylti1p3/deep_link_resource.py
@@ -69,8 +69,11 @@ class DeepLinkResource:
             "type": self._type,
             "title": self._title,
             "url": self._url,
-            "custom": self._custom_params,
         }
+
+        if self._custom_params:
+            res["custom"] = dict(self._custom_params)
+
         if self._lineitem:
             line_item: dict[str, object] = {
                 "scoreMaximum": self._lineitem.get_score_maximum(),
@@ -90,7 +93,10 @@ class DeepLinkResource:
 
             submission_review = self._lineitem.get_submission_review()
             if submission_review:
-                line_item["submissionReview"] = submission_review
+                submission_review_data = dict(submission_review)
+                if not submission_review_data.get("custom"):
+                    submission_review_data.pop("custom", None)
+                line_item["submissionReview"] = submission_review_data
 
             res["lineItem"] = line_item
 

--- a/tests/test_deep_link_resource.py
+++ b/tests/test_deep_link_resource.py
@@ -1,0 +1,43 @@
+import unittest
+from pylti1p3.deep_link_resource import DeepLinkResource
+from pylti1p3.lineitem import LineItem
+
+
+class TestDeepLinkResource(unittest.TestCase):
+    def test_to_dict_omits_custom_when_empty_or_unset(self):
+        resource = DeepLinkResource().set_title("Test title").set_url("https://tool.example/launch")
+        self.assertNotIn("custom", resource.to_dict())
+
+        resource_with_empty_custom = (
+            DeepLinkResource()
+            .set_title("Test title")
+            .set_url("https://tool.example/launch")
+            .set_custom_params({})
+        )
+        self.assertNotIn("custom", resource_with_empty_custom.to_dict())
+
+    def test_to_dict_includes_custom_when_non_empty(self):
+        custom_params = {"custom_param": "custom_value"}
+        resource = (
+            DeepLinkResource()
+            .set_title("Test title")
+            .set_url("https://tool.example/launch")
+            .set_custom_params(custom_params)
+        )
+
+        self.assertEqual(resource.to_dict().get("custom"), custom_params)
+
+    def test_to_dict_omits_empty_submission_review_custom(self):
+        lineitem = LineItem(
+            {
+                "scoreMaximum": 100,
+                "submissionReview": {"reviewableStatus": ["Pending"], "custom": {}},
+            }
+        )
+        resource = DeepLinkResource().set_title("Test title").set_url("https://tool.example/launch")
+        resource.set_lineitem(lineitem)
+
+        resource_dict = resource.to_dict()
+        submission_review = resource_dict.get("lineItem", {}).get("submissionReview")
+
+        self.assertEqual(submission_review, {"reviewableStatus": ["Pending"]})


### PR DESCRIPTION
### Motivation
- Prevent platforms (e.g., Moodle 4.5) from crashing when deep-link content items include an empty `custom: {}` by avoiding emission of empty custom objects.
- Also avoid generating nested empty `custom` inside `lineItem.submissionReview` which may be produced by existing line item payloads.

### Description
- Update `DeepLinkResource.to_dict()` to only add a top-level `custom` key when `self._custom_params` is non-empty and copy it into a plain `dict` when present.
- Sanitize `lineItem.submissionReview` by copying the submission review payload and removing its `custom` key when that nested `custom` is empty.
- Add `tests/test_deep_link_resource.py` with focused unit tests that assert omitted top-level `custom` when empty/unset, present when non-empty, and removal of empty `submissionReview.custom`.

### Testing
- Ran `python -m py_compile pylti1p3/deep_link_resource.py tests/test_deep_link_resource.py`, which succeeded.
- Ran `pytest -q tests/test_deep_link_resource.py`, which failed during collection due to missing test dependencies (`requests_mock`) in the environment.
- Ran `python -m unittest discover -s tests -p 'test_deep_link_resource.py'`, which failed during import because `requests` is not available in the test environment.
- Attempted `pip install requests requests_mock pytest`, but package installation failed due to outbound network/proxy restrictions, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cba0c9a1e48322970ba34494198af2)