### PR TITLE
ci: replace legacy tox workflow with uv-based CI on GitHub runners

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,18 +1,58 @@
-name: tox
-on: [push, pull_request]
+name: Continuous Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  tox:
+  test:
+    name: Test with Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
-    runs-on: ${{ matrix.os }}
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          python-version: ${{ matrix.python }}
-      - run: pip install --upgrade pip
-      - run: pip install "tox<4"
-      - run: tox -e py
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.9.26"
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run linting
+        run: uv run ruff check .
+
+      - name: Run formatting
+        run: uv run ruff format --check
+
+      - name: Run type checking
+        run: uv run basedpyright --level=warning
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
### Motivation
- Modernize the repository CI by replacing the old tox-based Actions workflow with a `uv`-driven pipeline that matches the provided example.
- Run on GitHub-hosted runners instead of self-hosted/Blacksmith to simplify maintenance and match the request to use GitHub runners.
- Align the CI Python matrix with the project `requires-python >=3.10` and pin action SHAs for reproducibility.
- Add basic concurrency and minimal permissions to avoid redundant runs and reduce surface area.

### Description
- Replaced the contents of `.github/workflows/tox.yml` with a new `Continuous Integration` workflow that triggers on `push`, `pull_request` for `main`, and `workflow_dispatch`.
- Added top-level `permissions: {}` and a `concurrency` group keyed by PR number or ref and changed the job to `test` which runs on `ubuntu-24.04` with a Python matrix `3.10`–`3.13`.
- Replaced the old `tox` steps with pinned action SHAs and steps to install `uv`, run `uv sync --all-extras --dev`, then run `ruff` lint/format checks, `basedpyright` type checks, and `pytest` tests.
- Kept `actions/checkout` with persisted-credentials disabled and pinned `astral-sh/setup-uv` and `actions/setup-python` steps.

### Testing
- Ran `uv --version`, which succeeded.
- Ran `uv sync --all-extras --dev`, which completed successfully and resolved project dependencies.
- Ran `uv run pytest -q`, which failed during test collection with `ModuleNotFoundError: No module named 'requests_mock'` (tests did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbbb9a5a50832282d09a1d07a00c67)