### PR TITLE
Add update/delete LineItem support and method-based ServiceConnector requests

### DIFF
--- a/pylti1p3/assignments_grades.py
+++ b/pylti1p3/assignments_grades.py
@@ -74,7 +74,7 @@ class AssignmentsGradesService:
         return self._service_connector.make_service_request(
             self._service_data["scope"],
             score_url,
-            is_post=True,
+            method="POST",
             data=grade.get_value(),
             content_type="application/vnd.ims.lis.v1.score+json",
         )
@@ -99,6 +99,53 @@ class AssignmentsGradesService:
             accept="application/vnd.ims.lis.v2.lineitem+json",
         )
         return LineItem(t.cast(TLineItem, lineitem_response["body"]))
+
+    def update_lineitem(self, lineitem: LineItem) -> LineItem:
+        """
+        Update an individual lineitem. Lineitem to be updated is identified by the lineitem ID.
+
+        :param lineitem: LineItem instance to be updated
+        :return: LineItem instance (updated, based on response from the LTI platform)
+        """
+        if not self.can_create_lineitem():
+            raise LtiException("Can't update lineitem: Missing required scope")
+
+        lineitem_url = lineitem.get_id()
+        if not lineitem_url:
+            raise LtiException("Can't update lineitem: Missing lineitem URL")
+
+        lineitem_response = self._service_connector.make_service_request(
+            self._service_data["scope"],
+            lineitem_url,
+            method="PUT",
+            data=lineitem.get_value(),
+            content_type="application/vnd.ims.lis.v2.lineitem+json",
+            accept="application/vnd.ims.lis.v2.lineitem+json",
+        )
+        if not isinstance(lineitem_response["body"], dict):
+            raise LtiException("Unknown response type received for update line item")
+        return LineItem(t.cast(TLineItem, lineitem_response["body"]))
+
+    def delete_lineitem(self, lineitem_url: str | None) -> None:
+        """
+        Delete an individual lineitem.
+
+        :param lineitem_url: endpoint for LTI line item
+        :return: None
+        """
+        if not self.can_create_lineitem():
+            raise LtiException("Can't delete lineitem: Missing required scope")
+
+        if not lineitem_url:
+            raise LtiException("Can't delete lineitem: Missing lineitem URL")
+
+        self._service_connector.make_service_request(
+            self._service_data["scope"],
+            lineitem_url,
+            method="DELETE",
+            content_type="application/vnd.ims.lis.v2.lineitem+json",
+            accept="application/vnd.ims.lis.v2.lineitem+json",
+        )
 
     def get_lineitems_page(self, lineitems_url: str | None = None) -> tuple[list, str | None]:
         """
@@ -231,7 +278,7 @@ class AssignmentsGradesService:
         created_lineitem = self._service_connector.make_service_request(
             self._service_data["scope"],
             self._service_data["lineitems"],
-            is_post=True,
+            method="POST",
             data=new_lineitem.get_value(),
             content_type="application/vnd.ims.lis.v2.lineitem+json",
             accept="application/vnd.ims.lis.v2.lineitem+json",

--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -9,7 +9,7 @@ from collections import abc
 
 import jwt  # type: ignore
 import requests
-from .exception import LtiServiceException
+from .exception import LtiException, LtiServiceException
 from .registration import Registration
 
 
@@ -111,7 +111,7 @@ class ServiceConnector:
         self,
         scopes: t.Sequence[str],
         url: str,
-        is_post: bool = False,
+        method: str = "GET",
         data: str | None = None,
         content_type: str = "application/json",
         accept: str = "application/json",
@@ -120,12 +120,22 @@ class ServiceConnector:
         access_token = self.get_access_token(scopes)
         headers = {"Authorization": "Bearer " + access_token, "Accept": accept}
 
-        if is_post:
-            headers["Content-Type"] = content_type
-            post_data = data or None
-            r = self._requests_session.post(url, data=post_data, headers=headers)
-        else:
+        if method == "GET":
             r = self._requests_session.get(url, headers=headers)
+        elif method == "DELETE":
+            r = self._requests_session.delete(url, headers=headers)
+        else:
+            headers["Content-Type"] = content_type
+            request_data = data or None
+            if method == "PUT":
+                r = self._requests_session.put(url, data=request_data, headers=headers)
+            elif method == "POST":
+                r = self._requests_session.post(url, data=request_data, headers=headers)
+            else:
+                raise LtiException(
+                    f'Unsupported method: {method}. Available methods are: '
+                    '"GET", "PUT", "POST", "DELETE".'
+                )
 
         if not r.ok:
             raise LtiServiceException(r)

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -143,3 +143,101 @@ class TestGrades(TestServicesBase):
 
                     resp = ags.put_grade(sc, sc_line_item)
                     self.assertEqual(expected_result, resp["body"])
+
+    def test_delete_lineitem(self):
+        from pylti1p3.contrib.django import DjangoMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+
+        with patch.object(DjangoMessageLaunch, "_get_jwt_body", autospec=True) as get_jwt_body:
+            message_launch = DjangoMessageLaunch(FakeRequest(), tool_conf)
+            line_items_url = "http://canvas.docker/api/lti/courses/1/line_items"
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body()
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with requests_mock.Mocker() as m:
+                    m.post(
+                        self._get_auth_token_url(),
+                        text=json.dumps(self._get_auth_token_response()),
+                    )
+
+                    line_item_url = "http://canvas.docker/api/lti/courses/1/line_items/1"
+                    line_items_response = [
+                        {
+                            "scoreMaximum": 100.0,
+                            "tag": "test",
+                            "id": line_item_url,
+                            "label": "Test",
+                        },
+                    ]
+                    m.get(line_items_url, text=json.dumps(line_items_response))
+                    m.delete(line_item_url, text="", status_code=204)
+
+                    ags = message_launch.validate_registration().get_ags()
+
+                    test_line_item = LineItem()
+                    test_line_item.set_tag("test").set_score_maximum(100).set_label("Test")
+                    line_item = ags.find_or_create_lineitem(test_line_item)
+                    self.assertIsNotNone(line_item)
+
+                    ags.delete_lineitem(line_item.get_id())
+
+                    # Auth, GET line items, DELETE line item
+                    self.assertEqual(len(m.request_history), 3)
+                    self.assertEqual(m.request_history[2].method, "DELETE")
+                    self.assertEqual(m.request_history[2].url, line_item_url)
+
+    def test_update_lineitem(self):
+        from pylti1p3.contrib.django import DjangoMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+
+        with patch.object(DjangoMessageLaunch, "_get_jwt_body", autospec=True) as get_jwt_body:
+            message_launch = DjangoMessageLaunch(FakeRequest(), tool_conf)
+            line_items_url = "http://canvas.docker/api/lti/courses/1/line_items"
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body()
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with requests_mock.Mocker() as m:
+                    m.post(
+                        self._get_auth_token_url(),
+                        text=json.dumps(self._get_auth_token_response()),
+                    )
+
+                    line_item_url = "http://canvas.docker/api/lti/courses/1/line_items/1"
+                    line_items_response = [
+                        {
+                            "id": line_item_url,
+                            "scoreMaximum": 100.0,
+                            "tag": "test",
+                            "label": "Test",
+                        },
+                    ]
+                    line_items_update_response = {
+                        "id": line_item_url,
+                        "scoreMaximum": 60.0,
+                        "tag": "test",
+                        "label": "Test",
+                    }
+
+                    m.get(line_items_url, text=json.dumps(line_items_response))
+                    m.put(line_item_url, text=json.dumps(line_items_update_response))
+
+                    ags = message_launch.validate_registration().get_ags()
+
+                    test_line_item = LineItem()
+                    test_line_item.set_tag("test").set_score_maximum(100).set_label("Test")
+
+                    line_item = ags.find_or_create_lineitem(test_line_item)
+                    self.assertIsNotNone(line_item)
+
+                    line_item.set_score_maximum(60)
+                    new_lineitem = ags.update_lineitem(line_item)
+
+                    self.assertEqual(new_lineitem.get_id(), line_item_url)
+                    self.assertEqual(new_lineitem.get_score_maximum(), 60.0)
+                    self.assertEqual(new_lineitem.get_tag(), "test")
+                    self.assertEqual(new_lineitem.get_label(), "Test")
+
+                    # Auth, GET line items, PUT line item
+                    self.assertEqual(len(m.request_history), 3)
+                    self.assertEqual(m.request_history[2].method, "PUT")
+                    self.assertEqual(m.request_history[2].url, line_item_url)


### PR DESCRIPTION
### Motivation
- Provide full lifecycle operations for LineItems (update and delete) from the Assignments & Grades Service (AGS). 
- Remove the boolean `is_post` flag in favor of an explicit HTTP `method` parameter so AGS can issue `PUT` and `DELETE` requests.
- Make request behavior explicit and validate unsupported methods to avoid accidental misuse.

### Description
- Replaced `ServiceConnector.make_service_request(..., is_post: bool)` with `make_service_request(..., method: str)` and added support for `GET`, `POST`, `PUT`, and `DELETE`, raising `LtiException` for unsupported methods; also imported `LtiException` where needed.  
- Added `AssignmentsGradesService.update_lineitem(lineitem: LineItem) -> LineItem` with scope checks, lineitem-URL validation, `PUT` call to the platform, and response-type validation.  
- Added `AssignmentsGradesService.delete_lineitem(lineitem_url: str | None) -> None` with scope and URL validation and a `DELETE` call to the platform.  
- Migrated existing AGS POST call sites to call `make_service_request(..., method="POST")` for consistency.  
- Added tests in `tests/test_grades.py` for `test_update_lineitem` and `test_delete_lineitem` that mock token/lineitem endpoints and assert the outgoing request method and URL plus response mapping.

### Testing
- Ran `pytest -q tests/test_grades.py`; test collection failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'requests_mock'`).
- Local CI / downstream test runs should exercise the new `test_update_lineitem` and `test_delete_lineitem` tests which validate `PUT` and `DELETE` request behavior when `requests_mock` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbbda85e7883228f83b6644a371a6d)