### PR TITLE
Introduce LtiConfigurationException and use in tool_config; tighten LineItem validation

### DIFF
--- a/pylti1p3/exception.py
+++ b/pylti1p3/exception.py
@@ -9,7 +9,13 @@ class LtiException(Exception):
     pass
 
 
-class OIDCException(Exception):
+class LtiConfigurationException(LtiException):
+    """Raised when the tool/platform configuration is invalid."""
+
+    pass
+
+
+class OIDCException(LtiException):
     """Raised when the OIDC login request is invalid."""
 
     pass

--- a/pylti1p3/lineitem.py
+++ b/pylti1p3/lineitem.py
@@ -171,7 +171,7 @@ class LineItem:
         custom: dict[str, str] | None = None,
     ) -> "LineItem":
         if not isinstance(reviewable_status, list):
-            raise Exception('Invalid "reviewable_status" argument')
+            raise ValueError('Invalid "reviewable_status" argument')
 
         self._submission_review: TSubmissionReview = {"reviewableStatus": reviewable_status}
         if label:

--- a/pylti1p3/tool_config/abstract.py
+++ b/pylti1p3/tool_config/abstract.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from ..actions import Action
 from ..request import Request
 from ..deployment import Deployment
+from ..exception import LtiConfigurationException
 from ..registration import Registration
 
 
@@ -130,11 +131,11 @@ class ToolConfAbstract(ABC):
                 reg = self.find_registration(iss)
             elif self.check_iss_has_many_clients(iss):
                 if not client_id:
-                    raise Exception("client_id is not specified")
+                    raise LtiConfigurationException("client_id is not specified")
                 reg = self.find_registration_by_params(
                     iss, client_id, action=action, request=request, jwt_body=jwt_body
                 )
             else:
-                raise Exception("Invalid issuer relation type")
+                raise LtiConfigurationException("Invalid issuer relation type")
             keys = reg.get_jwks()
         return {"keys": keys}

--- a/pylti1p3/tool_config/dict.py
+++ b/pylti1p3/tool_config/dict.py
@@ -5,6 +5,7 @@ import typing_extensions as te
 from collections import abc
 
 from ..deployment import Deployment
+from ..exception import LtiConfigurationException
 from ..registration import Registration, TKeySet
 from .abstract import ToolConfAbstract
 
@@ -83,7 +84,7 @@ class ToolConfDict(ToolConfAbstract):
         """
         super().__init__()
         if not isinstance(json_data, dict):
-            raise Exception("Invalid tool conf format. Must be dict")
+            raise LtiConfigurationException("Invalid tool conf format. Must be dict")
 
         for iss, iss_conf in json_data.items():
             if isinstance(iss_conf, dict):
@@ -94,7 +95,7 @@ class ToolConfDict(ToolConfAbstract):
                 for v in iss_conf:
                     self._validate_iss_config_item(iss, v)
             else:
-                raise Exception("Invalid tool conf format. Allowed types of elements: list or dict")
+                raise LtiConfigurationException("Invalid tool conf format. Allowed types of elements: list or dict")
 
         self._config = json_data
         self._private_key_one_client = {}
@@ -104,7 +105,9 @@ class ToolConfDict(ToolConfAbstract):
 
     def _validate_iss_config_item(self, iss: str, iss_conf: TIssConf):
         if not isinstance(iss_conf, dict):
-            raise ValueError(f"Invalid configuration {iss} for the {str(iss_conf)} issuer. Must be dict")
+            raise LtiConfigurationException(
+                f"Invalid configuration {iss} for the {str(iss_conf)} issuer. Must be dict"
+            )
         required_keys = [
             "auth_login_url",
             "auth_token_url",
@@ -113,9 +116,11 @@ class ToolConfDict(ToolConfAbstract):
         ]
         for key in required_keys:
             if key not in iss_conf:
-                raise ValueError(f"Key '{key}' is missing in the {str(iss_conf)} config for the {iss} issuer")
+                raise LtiConfigurationException(
+                    f"Key '{key}' is missing in the {str(iss_conf)} config for the {iss} issuer"
+                )
         if not isinstance(iss_conf["deployment_ids"], list):
-            raise ValueError(
+            raise LtiConfigurationException(
                 f"Invalid deployment_ids value in the {str(iss_conf)} config for the {iss} issuer. Must be a list"
             )
 
@@ -169,7 +174,7 @@ class ToolConfDict(ToolConfAbstract):
     def set_public_key(self, iss: str, key_content: str, client_id: str | None = None):
         if self.check_iss_has_many_clients(iss):
             if not client_id:
-                raise Exception("Can't set public key: missing client_id")
+                raise LtiConfigurationException("Can't set public key: missing client_id")
             if iss not in self._public_key_many_clients:
                 self._public_key_many_clients[iss] = {}
             self._public_key_many_clients[iss][client_id] = key_content
@@ -179,17 +184,17 @@ class ToolConfDict(ToolConfAbstract):
     def get_public_key(self, iss: str, client_id: str | None = None):
         if self.check_iss_has_many_clients(iss):
             if not client_id:
-                raise Exception("Can't get public key: missing client_id")
+                raise LtiConfigurationException("Can't get public key: missing client_id")
             clients_dict = self._public_key_many_clients.get(iss, {})
             if not isinstance(clients_dict, dict):
-                raise Exception("Invalid clients data")
+                raise LtiConfigurationException("Invalid clients data")
             return clients_dict.get(client_id)
         return self._public_key_one_client.get(iss)
 
     def set_private_key(self, iss: str, key_content: str, client_id: str | None = None):
         if self.check_iss_has_many_clients(iss):
             if not client_id:
-                raise Exception("Can't set private key: missing client_id")
+                raise LtiConfigurationException("Can't set private key: missing client_id")
             if iss not in self._private_key_many_clients:
                 self._private_key_many_clients[iss] = {}
             self._private_key_many_clients[iss][client_id] = key_content  # type: ignore
@@ -199,18 +204,18 @@ class ToolConfDict(ToolConfAbstract):
     def get_private_key(self, iss: str, client_id: str | None = None) -> str | None:
         if self.check_iss_has_many_clients(iss):
             if not client_id:
-                raise Exception("Can't get private key: missing client_id")
+                raise LtiConfigurationException("Can't get private key: missing client_id")
             clients_dict = self._private_key_many_clients.get(iss, {})
             if not isinstance(clients_dict, dict):
-                raise Exception("Invalid clients data")
+                raise LtiConfigurationException("Invalid clients data")
             return clients_dict.get(client_id)
         return self._private_key_one_client.get(iss)
 
     def get_iss_config(self, iss: str, client_id: str | None = None):
         if not self._config:
-            raise Exception("Config is not set")
+            raise LtiConfigurationException("Config is not set")
         if iss not in self._config:
-            raise Exception(f"iss {iss} not found in settings")
+            raise LtiConfigurationException(f"iss {iss} not found in settings")
         config_iss = self._config[iss]
 
         if isinstance(config_iss, list):
@@ -223,7 +228,7 @@ class ToolConfDict(ToolConfAbstract):
                     or (not client_id and items_len == 1)  # Only one item
                 ):
                     return subitem
-            raise Exception(f"iss {iss} [client_id={client_id}] not found in settings")
+            raise LtiConfigurationException(f"iss {iss} [client_id={client_id}] not found in settings")
         return config_iss
 
     @te.override

--- a/pylti1p3/tool_config/json_file.py
+++ b/pylti1p3/tool_config/json_file.py
@@ -4,6 +4,7 @@ import typing as t
 import json
 from pathlib import Path
 
+from ..exception import LtiConfigurationException
 from .dict import ToolConfDict, TIssConf, TJsonData
 
 
@@ -67,7 +68,7 @@ class ToolConfJsonFile(ToolConfDict):
         config_path = Path(config_file)
 
         if not config_path.is_file():
-            raise Exception("LTI tool config file not found: " + str(config_path))
+            raise LtiConfigurationException(f"LTI tool config file not found: {config_path}")
         self._configs_dir = str(config_path.parent)
 
         with config_path.open(encoding="utf-8") as cfg:
@@ -85,7 +86,7 @@ class ToolConfJsonFile(ToolConfDict):
     def _process_iss_conf_item(self, iss_conf: TIssConf, iss: str, client_id: str | None = None):
         private_key_file = iss_conf.get("private_key_file")
         if not private_key_file:
-            raise Exception("iss config error: private_key_file not found")
+            raise LtiConfigurationException("iss config error: private_key_file not found")
 
         if not private_key_file.startswith("/"):
             private_key_file = self._configs_dir + "/" + private_key_file


### PR DESCRIPTION
### Motivation
- Make configuration errors explicit and catchable by introducing a dedicated exception type instead of raising generic `Exception` or `ValueError` from tool-configuration code paths.
- Ensure configuration-related failures are part of the library's `LtiException` hierarchy for consistent handling by callers.
- Improve argument validation for `LineItem.set_submission_review` by raising a semantically appropriate exception for invalid input.

### Description
- Add `LtiConfigurationException` (subclass of `LtiException`) and make `OIDCException` inherit from `LtiException` in `pylti1p3/exception.py`.
- Replace generic `Exception`/`ValueError` raises with `LtiConfigurationException` in `pylti1p3/tool_config/abstract.py` for JWKS lookups and issuer relation errors.
- Replace configuration-related generic raises with `LtiConfigurationException` across `pylti1p3/tool_config/dict.py` (constructor validation, `_validate_iss_config_item`, key getters/setters, and issuer lookup).
- Replace file/config-related generic raises with `LtiConfigurationException` in `pylti1p3/tool_config/json_file.py` for missing config file and missing `private_key_file`.
- Update `pylti1p3/lineitem.py` to raise `ValueError` when `reviewable_status` is not a list.

### Testing
- Ran `pytest -q` in the repository and test collection failed with `ModuleNotFoundError: No module named 'requests_mock'`, causing 10 errors during collection and preventing the test suite from running to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcb1bfd648322aab985fee9babf79)