### PR TITLE
Add Platform Notification Service support

### DIFF
--- a/pylti1p3/message_launch.py
+++ b/pylti1p3/message_launch.py
@@ -26,6 +26,7 @@ from .message_validators.privacy_launch import PrivacyLaunchValidator
 from .message_validators.resource_message import ResourceMessageValidator
 from .message_validators.submission_review import SubmissionReviewLaunchValidator
 from .names_roles import NamesRolesProvisioningService, TNamesAndRolesData
+from .platform_notification import PlatformNotificationService, TPlatformNotificationServiceData
 from .roles import (
     StaffRole,
     StudentRole,
@@ -139,6 +140,7 @@ TLaunchData = t.TypedDict(
         "https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice": TGroupsServiceData,
         "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice": TNamesAndRolesData,
         "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": TAssignmentsGradersData,
+        "https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice": TPlatformNotificationServiceData,
         "https://purl.imsglobal.org/spec/lti/claim/tool_platform": TToolPlatformClaim,
         "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": list[str],
         "https://purl.imsglobal.org/spec/lti/claim/lti1p1": TMigrationClaim,
@@ -419,6 +421,35 @@ class MessageLaunch(t.Generic[RequestT, ToolConfT, SessionServiceT, CookieServic
         if not context_groups_url:
             raise LtiException("context_groups_url is not set in groupsservice section")
         return CourseGroupsService(connector, groups_service_data)
+
+    def has_pns(self) -> bool:
+        """
+        Returns whether or not the current launch can use the platform notification service.
+
+        :return: bool
+        """
+        platform_notification_data = self._get_jwt_body().get(
+            "https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice", {}
+        )
+        return platform_notification_data.get("platform_notification_service_url", None) is not None
+
+    def get_pns(self) -> PlatformNotificationService:
+        """
+        Fetches an instance of the platform notification service for the current launch.
+
+        :return: PlatformNotificationService
+        """
+        assert self._registration is not None, "Registration not yet set"
+        connector = self.get_service_connector()
+        platform_notification_data = self._get_jwt_body().get(
+            "https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice"
+        )
+        if not platform_notification_data:
+            raise LtiException("platformnotificationservice is not set in jwt body")
+        service_url = platform_notification_data.get("platform_notification_service_url", None)
+        if not service_url:
+            raise LtiException("platform_notification_service_url is not set in platformnotificationservice section")
+        return PlatformNotificationService(connector, platform_notification_data)
 
     def get_deep_link(self) -> DeepLink:
         """

--- a/pylti1p3/platform_notification.py
+++ b/pylti1p3/platform_notification.py
@@ -1,0 +1,92 @@
+"""Platform Notification Service helpers for notice-handler registration and delivery payloads."""
+
+import json
+import typing as t
+import typing_extensions as te
+
+from .service_connector import ServiceConnector, TServiceConnectorResponse
+
+
+class TPlatformNotificationServiceData(t.TypedDict, total=False):
+    """Platform Notification Service metadata from the launch JWT."""
+
+    service_versions: te.Required[list[str]]
+    platform_notification_service_url: te.Required[str]
+    scope: te.Required[list[t.Literal["https://purl.imsglobal.org/spec/lti/scope/noticehandlers"]]]
+    notice_types_supported: list[str]
+
+
+class TNoticeHandler(t.TypedDict):
+    """Single notice-handler record used for registration/list responses."""
+
+    notice_type: str
+    handler: str
+
+
+class TNoticeHandlersResponse(t.TypedDict, total=False):
+    """Notice-handler listing response from the platform endpoint."""
+
+    client_id: str | int
+    deployment_id: str
+    notice_handlers: list[TNoticeHandler]
+
+
+class TNoticeDeliveryItem(t.TypedDict):
+    """Single JWT notice item delivered to the tool's webhook."""
+
+    jwt: str
+
+
+class TNoticeDeliveryPayload(t.TypedDict):
+    """Webhook payload posted by the platform notification service."""
+
+    notices: list[TNoticeDeliveryItem]
+
+
+class PlatformNotificationService:
+    """Registers and lists platform notice handlers for a launch context."""
+
+    _service_connector: ServiceConnector
+    _service_data: TPlatformNotificationServiceData
+
+    def __init__(
+        self,
+        service_connector: ServiceConnector,
+        service_data: TPlatformNotificationServiceData,
+    ):
+        self._service_connector = service_connector
+        self._service_data = service_data
+
+    def get_supported_notice_types(self) -> list[str]:
+        return self._service_data.get("notice_types_supported", [])
+
+    def get_notice_handlers(self) -> TServiceConnectorResponse:
+        return self._service_connector.make_service_request(
+            self._service_data["scope"],
+            self._service_data["platform_notification_service_url"],
+            method="GET",
+        )
+
+    def register_notice_handler(self, notice_type: str, handler: str) -> TServiceConnectorResponse:
+        data = json.dumps(
+            {
+                "notice_type": notice_type,
+                "handler": handler,
+            }
+        )
+
+        return self._service_connector.make_service_request(
+            self._service_data["scope"],
+            self._service_data["platform_notification_service_url"],
+            method="PUT",
+            data=data,
+            content_type="application/json",
+            accept="application/json",
+        )
+
+    def remove_notice_handler(self, notice_type: str) -> TServiceConnectorResponse:
+        return self.register_notice_handler(notice_type, "")
+
+    @staticmethod
+    def get_notice_jwts(payload: TNoticeDeliveryPayload) -> list[str]:
+        return [notice.get("jwt", "") for notice in payload.get("notices", []) if notice.get("jwt")]

--- a/tests/test_platform_notification.py
+++ b/tests/test_platform_notification.py
@@ -1,0 +1,117 @@
+import json
+from unittest.mock import patch
+
+import requests_mock
+
+from .base import TestServicesBase
+from .request import FakeRequest
+from .tool_config import get_test_tool_conf
+
+
+class TestPlatformNotificationService(TestServicesBase):
+    def _get_jwt_body_with_pns(self):
+        jwt_body = self._get_jwt_body().copy()
+        jwt_body["https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice"] = {
+            "service_versions": ["1.0"],
+            "platform_notification_service_url": "http://canvas.docker/api/lti/notice-handlers/1",
+            "scope": ["https://purl.imsglobal.org/spec/lti/scope/noticehandlers"],
+            "notice_types_supported": [
+                "LtiHelloWorldNotice",
+                "LtiContextCopyNotice",
+            ],
+        }
+        return jwt_body
+
+    def test_register_and_get_notice_handlers(self):
+        # pylint: disable=import-outside-toplevel
+        from pylti1p3.contrib.flask import FlaskMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+        notice_service_url = "http://canvas.docker/api/lti/notice-handlers/1"
+
+        with patch.object(FlaskMessageLaunch, "_get_jwt_body", autospec=True) as get_jwt_body:
+            message_launch = FlaskMessageLaunch(FakeRequest(), tool_conf)
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body_with_pns()
+
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with requests_mock.Mocker() as m:
+                    m.post(
+                        self._get_auth_token_url(),
+                        text=json.dumps(self._get_auth_token_response()),
+                    )
+
+                    m.put(
+                        notice_service_url,
+                        text=json.dumps(
+                            {
+                                "notice_type": "LtiContextCopyNotice",
+                                "handler": "https://tool.example.com/notice_handlers/1",
+                            }
+                        ),
+                    )
+                    m.get(
+                        notice_service_url,
+                        text=json.dumps(
+                            {
+                                "client_id": 10000000000068,
+                                "deployment_id": "106:abc",
+                                "notice_handlers": [
+                                    {
+                                        "notice_type": "LtiContextCopyNotice",
+                                        "handler": "https://tool.example.com/notice_handlers/1",
+                                    }
+                                ],
+                            }
+                        ),
+                    )
+
+                    pns = message_launch.validate_registration().get_pns()
+                    self.assertEqual(
+                        pns.get_supported_notice_types(),
+                        ["LtiHelloWorldNotice", "LtiContextCopyNotice"],
+                    )
+
+                    register_response = pns.register_notice_handler(
+                        "LtiContextCopyNotice",
+                        "https://tool.example.com/notice_handlers/1",
+                    )
+                    self.assertEqual(
+                        register_response["body"],
+                        {
+                            "notice_type": "LtiContextCopyNotice",
+                            "handler": "https://tool.example.com/notice_handlers/1",
+                        },
+                    )
+
+                    handlers_response = pns.get_notice_handlers()
+                    self.assertEqual(handlers_response["body"]["client_id"], 10000000000068)
+                    self.assertEqual(len(handlers_response["body"]["notice_handlers"]), 1)
+
+    def test_has_pns(self):
+        # pylint: disable=import-outside-toplevel
+        from pylti1p3.contrib.flask import FlaskMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+
+        with patch.object(FlaskMessageLaunch, "_get_jwt_body", autospec=True) as get_jwt_body:
+            message_launch = FlaskMessageLaunch(FakeRequest(), tool_conf)
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body_with_pns()
+            self.assertTrue(message_launch.has_pns())
+
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body()
+            self.assertFalse(message_launch.has_pns())
+
+    def test_get_notice_jwts_from_payload(self):
+        # pylint: disable=import-outside-toplevel
+        from pylti1p3.platform_notification import PlatformNotificationService
+
+        payload = {
+            "notices": [
+                {"jwt": "header.payload.signature"},
+                {"jwt": "header.payload2.signature2"},
+            ]
+        }
+        self.assertEqual(
+            PlatformNotificationService.get_notice_jwts(payload),
+            ["header.payload.signature", "header.payload2.signature2"],
+        )


### PR DESCRIPTION
### Motivation
- Implement support for the LTI Platform Notification Service to allow tools to register/list/remove notice handlers (webhooks) advertised in the `platformnotificationservice` claim and to parse delivered notice payloads. 

### Description
- Add `pylti1p3/platform_notification.py` which defines typed models for the claim and delivery payload and provides `PlatformNotificationService` with `get_supported_notice_types()`, `get_notice_handlers()`, `register_notice_handler()`, `remove_notice_handler()`, and `get_notice_jwts()` helpers. 
- Expose the service from `MessageLaunch` by adding claim typing for `https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice` and new helpers `has_pns()` and `get_pns()` to detect capability and construct a `PlatformNotificationService` instance. 
- Add integration-style tests in `tests/test_platform_notification.py` covering capability detection, registration/listing flow against mocked endpoints, and webhook JWT extraction. 

### Testing
- `python -m compileall pylti1p3 tests/test_platform_notification.py` succeeded and module files compiled. 
- Attempted `pytest -q tests/test_platform_notification.py tests/test_course_groups.py tests/test_names_roles.py`, but test collection failed in this environment due to a missing test dependency `requests_mock` (error: `ModuleNotFoundError: No module named 'requests_mock'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf76f18cc88322bfd5fda86366390e)