### PR TITLE
Remove deprecated reviewableStatus from submissionReview payload

### DIFF
--- a/pylti1p3/deep_link_resource.py
+++ b/pylti1p3/deep_link_resource.py
@@ -92,7 +92,7 @@ class DeepLinkResource:
                 line_item["tag"] = tag
 
             submission_review = self._lineitem.get_submission_review()
-            if submission_review:
+            if submission_review is not None:
                 submission_review_data = dict(submission_review)
                 if not submission_review_data.get("custom"):
                     submission_review_data.pop("custom", None)

--- a/pylti1p3/lineitem.py
+++ b/pylti1p3/lineitem.py
@@ -2,16 +2,12 @@
 
 import json
 import typing as t
-import typing_extensions as te
 from .exception import LtiException
 
 
 class TSubmissionReview(t.TypedDict, total=False):
     """Submission review data attached to a line item."""
 
-    # Required data
-    reviewableStatus: te.Required[list]
-    # Optional data
     label: str
     url: str
     custom: dict[str, str]
@@ -165,15 +161,11 @@ class LineItem:
 
     def set_submission_review(
         self,
-        reviewable_status: list,
         label: str | None = None,
         url: str | None = None,
         custom: dict[str, str] | None = None,
     ) -> "LineItem":
-        if not isinstance(reviewable_status, list):
-            raise ValueError('Invalid "reviewable_status" argument')
-
-        self._submission_review: TSubmissionReview = {"reviewableStatus": reviewable_status}
+        self._submission_review = {}
         if label:
             self._submission_review["label"] = label
         if url:
@@ -195,4 +187,10 @@ class LineItem:
             "endDateTime": self._end_date_time,
             "submissionReview": self._submission_review,
         }
-        return json.dumps({k: v for k, v in data.items() if v})
+        return json.dumps(
+            {
+                k: v
+                for k, v in data.items()
+                if (k == "submissionReview" and v is not None) or (k != "submissionReview" and v)
+            }
+        )

--- a/tests/test_deep_link_resource.py
+++ b/tests/test_deep_link_resource.py
@@ -31,7 +31,7 @@ class TestDeepLinkResource(unittest.TestCase):
         lineitem = LineItem(
             {
                 "scoreMaximum": 100,
-                "submissionReview": {"reviewableStatus": ["Pending"], "custom": {}},
+                "submissionReview": {"custom": {}},
             }
         )
         resource = DeepLinkResource().set_title("Test title").set_url("https://tool.example/launch")
@@ -40,4 +40,14 @@ class TestDeepLinkResource(unittest.TestCase):
         resource_dict = resource.to_dict()
         submission_review = resource_dict.get("lineItem", {}).get("submissionReview")
 
-        self.assertEqual(submission_review, {"reviewableStatus": ["Pending"]})
+        self.assertEqual(submission_review, {})
+
+    def test_to_dict_includes_empty_submission_review(self):
+        lineitem = LineItem({"scoreMaximum": 100}).set_submission_review()
+        resource = DeepLinkResource().set_title("Test title").set_url("https://tool.example/launch")
+        resource.set_lineitem(lineitem)
+
+        resource_dict = resource.to_dict()
+        submission_review = resource_dict.get("lineItem", {}).get("submissionReview")
+
+        self.assertEqual(submission_review, {})


### PR DESCRIPTION
### Motivation
- The LTI Submission Review spec no longer uses `reviewableStatus` in the `submissionReview` line item object, so the library must stop producing or expecting that property.
- Tools must still be able to advertise submission review support by sending an explicit empty object (`{}`) for `submissionReview` when no options are supplied.
- Ensure deep-link generation and serialization align with the updated spec while keeping `custom` pruned when empty.

### Description
- Remove `reviewableStatus` from the `TSubmissionReview` typed schema and stop requiring it in the builder API by changing `LineItem.set_submission_review()` to accept only `label`, `url`, and `custom` and to build an explicit `{}` when no options are provided (`pylti1p3/lineitem.py`).
- Preserve `submissionReview` in `LineItem.get_value()` whenever it has been explicitly set (including empty `{}`), while still omitting other empty fields in the line item payload (`pylti1p3/lineitem.py`).
- Update `DeepLinkResource.to_dict()` to include `submissionReview` when the line item explicitly contains it (including empty objects) and to strip an empty `custom` field inside `submissionReview` (`pylti1p3/deep_link_resource.py`).
- Update tests to reflect the new payload shape and to assert that an explicitly-empty `submissionReview` object is emitted (`tests/test_deep_link_resource.py`).

### Testing
- Attempted `pytest -q tests/test_deep_link_resource.py tests/test_submission_review_launch.py`, but test collection failed due to a missing test dependency `requests_mock` in the environment, so the suite did not run to completion.
- Ran `python -m unittest tests.test_deep_link_resource`, which could not import test helpers because `requests_mock` is required by `tests/__init__.py`, so the run failed during collection.
- Performed a quick runtime smoke check instantiating `LineItem` and `DeepLinkResource`, but that check failed in this environment because the `requests` dependency (imported by the package) is not installed; the library changes themselves are local and consistent with the spec, but CI/test runs require the missing test/runtime dependencies to be present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d632cc3b008322aab6e258a073b3d9)