### PR TITLE
Add partitioned cookie handling for secure iframe flows across contrib adapters

### DIFF
--- a/pylti1p3/contrib/django/cookie.py
+++ b/pylti1p3/contrib/django/cookie.py
@@ -8,6 +8,8 @@ from pylti1p3.cookie import CookieService
 # pylint: disable=protected-access
 if "samesite" not in Cookie.Morsel._reserved:  # type: ignore
     Cookie.Morsel._reserved.setdefault("samesite", "SameSite")  # type: ignore
+if "partitioned" not in Cookie.Morsel._reserved:  # type: ignore
+    Cookie.Morsel._reserved.setdefault("partitioned", "Partitioned")  # type: ignore
 
 
 class DjangoCookieService(CookieService):
@@ -56,5 +58,7 @@ class DjangoCookieService(CookieService):
                 else:
                     response.set_cookie(key, **kwargs)
                     response.cookies[key]["samesite"] = "None"
+
+                response.cookies[key]["partitioned"] = True
             else:
                 response.set_cookie(key, **kwargs)

--- a/pylti1p3/contrib/fastapi/cookie.py
+++ b/pylti1p3/contrib/fastapi/cookie.py
@@ -42,4 +42,5 @@ class FastAPICookieService(CookieService):
             }
             if is_secure:
                 cookie_kwargs["samesite"] = "None"
+                cookie_kwargs["partitioned"] = True
             response.set_cookie(**cookie_kwargs)

--- a/pylti1p3/contrib/flask/cookie.py
+++ b/pylti1p3/contrib/flask/cookie.py
@@ -35,4 +35,5 @@ class FlaskCookieService(CookieService):
 
             if self._request.is_secure():
                 cookie_kwargs["samesite"] = "None"
+                cookie_kwargs["partitioned"] = True
             response.set_cookie(**cookie_kwargs)

--- a/pylti1p3/cookies_allowed_check.py
+++ b/pylti1p3/cookies_allowed_check.py
@@ -93,7 +93,7 @@ class CookiesAllowedCheckPage:
         function checkCookiesAllowed() {
             var cookie = "lti1p3_test_cookie=1; path=/";
             if (siteProtocol === 'https') {
-                cookie = cookie + '; SameSite=None; secure';
+                cookie = cookie + '; SameSite=None; secure; partitioned';
             }
             document.cookie = cookie;
             var res = document.cookie.indexOf("lti1p3_test_cookie") !== -1;

--- a/tests/django_mixin.py
+++ b/tests/django_mixin.py
@@ -123,9 +123,11 @@ class DjangoMixin:
                 if secure:
                     self.assertTrue(cookie_dict["secure"])
                     self.assertEqual(cookie_dict["samesite"], "None")
+                    self.assertTrue(cookie_dict["partitioned"])
                 else:
                     self.assertFalse(cookie_dict["secure"])
                     self.assertTrue("samesite" not in cookie_dict)
+                    self.assertTrue("partitioned" not in cookie_dict)
 
         return tool_conf, request, response
 

--- a/tests/flask_mixin.py
+++ b/tests/flask_mixin.py
@@ -121,9 +121,11 @@ class FlaskMixin:
                 if secure:
                     self.assertTrue("Secure" in set_cookie_header)
                     self.assertTrue("SameSite=None" in set_cookie_header)
+                    self.assertTrue("Partitioned" in set_cookie_header)
                 else:
                     self.assertFalse("Secure" in set_cookie_header)
                     self.assertFalse("SameSite" in set_cookie_header)
+                    self.assertFalse("Partitioned" in set_cookie_header)
 
                 # check session data
                 if cache:


### PR DESCRIPTION
### Motivation
- Browsers are starting to block cookies in IFRAMEs unless the cookie is marked Partitioned, so state cookies used by LTI flows must include this attribute when set over HTTPS.
- A Flask-only patch existed to set Partitioned for secure cookies; this change extends that behavior to other framework adapters to provide consistent iframe behavior across integrations.
- Django needs special handling (registering the `partitioned` morsel and preserving SameSite compatibility across Django versions), so the change is provided as an initial draft for review and further verification in target deployments.

### Description
- Flask: set `partitioned=True` on secure state cookies in `pylti1p3/contrib/flask/cookie.py` alongside `samesite='None'`.
- FastAPI: mirror the Flask behavior by adding `partitioned=True` for secure state cookies in `pylti1p3/contrib/fastapi/cookie.py`.
- Django: register `partitioned` in `http.cookies.Morsel._reserved` when missing and set `response.cookies[key]["partitioned"] = True` for secure cookies while preserving existing SameSite compatibility handling in `pylti1p3/contrib/django/cookie.py`.
- Cookie probe JS and tests: include `partitioned` on the HTTPS test cookie string in `pylti1p3/cookies_allowed_check.py`, and update test mixins in `tests/flask_mixin.py` and `tests/django_mixin.py` to assert presence/absence of the Partitioned attribute for secure/non-secure flows.

### Testing
- Attempted a targeted pytest run referencing a specific test spec but the invocation referenced a non-existent test path, so no tests were executed in that run (invalid path/spec).
- Ran `pytest -q tests/test_resource_link.py -k 'TestDjangoResourceLink or TestFlaskResourceLink'`, but test collection failed due to a missing dependency (`requests_mock`), so no tests completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d658dccf2c8322a954a4068e243b74)